### PR TITLE
Added the `is` and `get` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,67 @@ var Typpy = require("typpy");
 console.log(Typpy(0));
 // => "number"
 
-console.log(Typpy(""));
-// => "string"
+console.log(Typpy("", String));
+// => true
 
-console.log(Typpy(null));
-// => "null"
+console.log(Typpy.is(null, "null"));
+// => true
 
-console.log(Typpy([]));
-// => "array"
+console.log(Typpy.get([]));
+// => Array
+
+console.log(Typpy({}, true));
+// => "object"
+
+console.log(Typpy({}, Object));
+// => true
 
 ```
 
 ## Documentation
 
-### `Typpy(input)`
-Gets the type of the input value.
+### `Typpy(input, target)`
+Gets the type of the input value or compares it
+with a provided type.
+
+Usage:
+
+```js
+Typpy({}) // => "object"
+Typpy(42, Number); // => true
+Typpy.get([], "array"); => true
+```
 
 #### Params
 - **Anything** `input`: The input value.
+- **Constructor|String** `target`: The target type. It could be a string (e.g. `"array"`) or a
+constructor (e.g. `Array`).
 
 #### Return
-- **String** The input value type (always lowercase).
+- **String|Boolean** It returns `true` if the input has the provided type `target` (if was provided),
+`false` if the input type does *not* have the provided type
+`target` or the stringified type of the input (always lowercase).
+
+### `Typpy.is(input, target)`
+Checks if the input value has a specified type.
+
+#### Params
+- **Anything** `input`: The input value.
+- **Constructor|String** `target`: The target type. It could be a string (e.g. `"array"`) or a
+constructor (e.g. `Array`).
+
+#### Return
+- **Boolean** `true`, if the input has the same type with the target or `false` otherwise.
+
+### `Typpy.get(input, str)`
+Gets the type of the input value. This is used internally.
+
+#### Params
+- **Anything** `input`: The input value.
+- **Boolean** `str`: A flag to indicate if the return value should be a string or not.
+
+#### Return
+- **Constructor|String** The input value constructor (if any) or the stringified type (always lowercase).
 
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].

--- a/example/index.js
+++ b/example/index.js
@@ -4,17 +4,17 @@ var Typpy = require("../lib");
 console.log(Typpy(0));
 // => "number"
 
-console.log(Typpy(""));
-// => "string"
+console.log(Typpy("", String));
+// => true
 
-console.log(Typpy(null));
-// => "null"
+console.log(Typpy.is(null, "null"));
+// => true
 
-console.log(Typpy([]));
-// => "array"
+console.log(Typpy.get([]));
+// => Array
 
-console.log(Typpy({}));
+console.log(Typpy({}, true));
 // => "object"
 
 console.log(Typpy({}, Object));
-// => "object"
+// => true

--- a/example/index.js
+++ b/example/index.js
@@ -15,3 +15,6 @@ console.log(Typpy([]));
 
 console.log(Typpy({}));
 // => "object"
+
+console.log(Typpy({}, Object));
+// => "object"

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ function Typpy(input, target) {
     if (arguments.length === 2) {
         return Typpy.is(input, target);
     }
-    return Typpy.get(input);
+    return Typpy.get(input, true);
 }
 
 /**
@@ -35,14 +35,15 @@ function Typpy(input, target) {
  *
  * @name is
  * @function
+ * @param {Anything} input The input value.
  * @param {Constructor|String} target The target type.
  * It could be a string (e.g. `"array"`) or a
  * constructor (e.g. `Array`).
  * @return {Boolean} `true`, if the input has the same
  * type with the target or `false` otherwise.
  */
-Typpy.is = function (target) {
-    return Typpy.get(this.input, typeof target === "string") === target;
+Typpy.is = function (input, target) {
+    return Typpy.get(input, typeof target === "string") === target;
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,10 +30,10 @@ function Typpy(input, target) {
 }
 
 /**
- * is
+ * Typpy.is
  * Checks if the input value has a specified type.
  *
- * @name is
+ * @name Typpy.is
  * @function
  * @param {Anything} input The input value.
  * @param {Constructor|String} target The target type.
@@ -50,7 +50,7 @@ Typpy.is = function (input, target) {
  * Typpy.get
  * Gets the type of the input value. This is used internally.
  *
- * @name Typpy
+ * @name Typpy.get
  * @function
  * @param {Anything} input The input value.
  * @param {Boolean} str A flag to indicate if the return value

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,33 +1,32 @@
 /**
  * Typpy
- * Creates a new `Typpy` instance.
+ * Gets the type of the input value or compares it
+ * with a provided type.
  *
  * Usage:
  *
  * ```js
- * // Let Typpy to create a new instance
- * Typpy({}).is(Object); // => true
- *
- * // Use the `new` keyword
- * new Typpy({}).is(Object); // => true
- *
- * // Use the `getTypeOf` method
- * Typpy.getTypeOf(42); // => Number
- *
- * // Stringify the type
- * Typpy.getTypeOf([], true); => "array"
+ * Typpy({}) // => "object"
+ * Typpy(42, Number); // => true
+ * Typpy.get([], "array"); => true
  * ```
  *
  * @name Typpy
  * @function
  * @param {Anything} input The input value.
- * @return {Typpy} The `Typpy` instance.
+ * @param {Constructor|String} target The target type.
+ * It could be a string (e.g. `"array"`) or a
+ * constructor (e.g. `Array`).
+ * @return {String|Boolean} It returns `true` if the
+ * input has the provided type `target` (if was provided),
+ * `false` if the input type does *not* have the provided type
+ * `target` or the stringified type of the input (always lowercase).
  */
-function Typpy(input) {
-    if (Typpy.getTypeOf(this) !== Typpy) {
-        return new Typpy(input);
+function Typpy(input, target) {
+    if (arguments.length === 2) {
+        return Typpy.is(input, target);
     }
-    this.input = input;
+    return Typpy.get(input);
 }
 
 /**
@@ -36,15 +35,18 @@ function Typpy(input) {
  *
  * @name is
  * @function
- * @param {String} target The target type. It could be a string (e.g. `"array"`) or a constructor (e.g. `Array`).
- * @return {Boolean} `true`, if the input has the same type with the target or `false` otherwise.
+ * @param {Constructor|String} target The target type.
+ * It could be a string (e.g. `"array"`) or a
+ * constructor (e.g. `Array`).
+ * @return {Boolean} `true`, if the input has the same
+ * type with the target or `false` otherwise.
  */
-Typpy.prototype.is = function (target) {
-    return Typpy.getTypeOf(this.input, typeof target === "string") === target;
+Typpy.is = function (target) {
+    return Typpy.get(this.input, typeof target === "string") === target;
 };
 
 /**
- * Typpy.getTypeOf
+ * Typpy.get
  * Gets the type of the input value. This is used internally.
  *
  * @name Typpy
@@ -55,7 +57,7 @@ Typpy.prototype.is = function (target) {
  * @return {Constructor|String} The input value constructor
  * (if any) or the stringified type (always lowercase).
  */
-Typpy.getTypeOf = function (input, str) {
+Typpy.get = function (input, str) {
 
     if (typeof input === "string") {
         return str ? "string" : String;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,79 @@
 /**
  * Typpy
- * Gets the type of the input value.
+ * Creates a new `Typpy` instance.
+ *
+ * Usage:
+ *
+ * ```js
+ * // Let Typpy to create a new instance
+ * Typpy({}).is(Object); // => true
+ *
+ * // Use the `new` keyword
+ * new Typpy({}).is(Object); // => true
+ *
+ * // Use the `getTypeOf` method
+ * Typpy.getTypeOf(42); // => Number
+ *
+ * // Stringify the type
+ * Typpy.getTypeOf([], true); => "array"
+ * ```
  *
  * @name Typpy
  * @function
  * @param {Anything} input The input value.
- * @return {String} The input value type (always lowercase).
+ * @return {Typpy} The `Typpy` instance.
  */
 function Typpy(input) {
+    if (Typpy.getTypeOf(this) !== Typpy) {
+        return new Typpy(input);
+    }
+    this.input = input;
+}
+
+/**
+ * is
+ * Checks if the input value has a specified type.
+ *
+ * @name is
+ * @function
+ * @param {String} target The target type. It could be a string (e.g. `"array"`) or a constructor (e.g. `Array`).
+ * @return {Boolean} `true`, if the input has the same type with the target or `false` otherwise.
+ */
+Typpy.prototype.is = function (target) {
+    return Typpy.getTypeOf(this.input, typeof target === "string") === target;
+};
+
+/**
+ * Typpy.getTypeOf
+ * Gets the type of the input value. This is used internally.
+ *
+ * @name Typpy
+ * @function
+ * @param {Anything} input The input value.
+ * @param {Boolean} str A flag to indicate if the return value
+ * should be a string or not.
+ * @return {Constructor|String} The input value constructor
+ * (if any) or the stringified type (always lowercase).
+ */
+Typpy.getTypeOf = function (input, str) {
 
     if (typeof input === "string") {
-        return "string";
+        return str ? "string" : String;
     }
 
     if (null === input) {
-        return "null";
+        return str ? "null" : null;
     }
 
     if (undefined === input) {
-        return "undefined";
+        return str ? "undefined" : undefined;
     }
 
-    return input.constructor.name.toLowerCase();
-}
+    if (input !== input) {
+        return str ? "nan" : NaN;
+    }
+
+    return str ? input.constructor.name.toLowerCase() : input.constructor;
+};
 
 module.exports = Typpy;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typpy",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A better typeof for JavaScript.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var Typpy = require("../lib")
 const TESTS = [
     ["check null", null, "null"]
   , ["check undefined", undefined, "undefined"]
+  , ["check NaN", NaN, "nan"]
   , ["support objects", {}, "object"]
   , ["support numbers", 42, "number"]
   , ["support strings", "hello", "string"]
@@ -19,7 +20,7 @@ const TESTS = [
 
 TESTS.forEach(function (c) {
     it("should " + c[0], function (cb) {
-        Assert(Typpy(c[1]), c[2]);
+        Assert.equal(Typpy(c[1]), c[2]);
         cb();
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ const TESTS = [
 
 TESTS.forEach(function (c) {
     it("should " + c[0], function (cb) {
-        Assert.equal(Typpy(c[1]).is(c[2]), true);
+        Assert.equal(Typpy(c[1], c[2]), true);
         cb();
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,8 @@ const TESTS = [
 TESTS.forEach(function (c) {
     it("should " + c[0], function (cb) {
         Assert.equal(Typpy(c[1], c[2]), true);
+        Assert.equal(Typpy.is(c[1], c[2]), true);
+        Assert.equal(Typpy(c[1]), c[2]);
         cb();
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ const TESTS = [
 
 TESTS.forEach(function (c) {
     it("should " + c[0], function (cb) {
-        Assert.equal(Typpy(c[1]), c[2]);
+        Assert.equal(Typpy(c[1]).is(c[2]), true);
         cb();
     });
 });


### PR DESCRIPTION
The old usage is still there (`Typpy([]) === "array"`) but now `Typpy` is a little bit smarter: if we pass a second argument, `Typpy` returns a `Boolean` value:

``` js
Typpy("Hello World", String); // => true
Typpy(42, "number"); // => true
```

Internally it uses the following new functions:
- `Typpy.is`: checks if the input has the same type with a provided type (constructor or string)
- `Typpy.get`: gets the input value type and returns the constructor or the string

Bonus, starting with this release, `NaN` is handled too. It's not considered a number but a `NaN` (_not a number_). :sparkles: 
